### PR TITLE
First host implementation.

### DIFF
--- a/host.py
+++ b/host.py
@@ -24,7 +24,7 @@ class Host(object):
 
     PROCESSING_TIME = 0.0000000000000001
     
-    def __init__(self, env, host_id, link, flows):
+    def __init__(self, env, host_id, link=None, flows={}):
         """
             Sets up a network endpoint host object.
         
@@ -34,11 +34,13 @@ class Host(object):
                     host_id:
                         Identification number of host.
                     link:
-                        Link object connecting host to the internet.
+                        Link object connecting host to the internet. Optional
+                        during initialization, defaults to None.
                     flows:
                         Dictionary of flows within host with flow IDs as keys.
                         Initially, this should only consist of sending flows
-                        since receiving flows are generated on-the-fly.
+                        since receiving flows are generated on-the-fly. Optional
+                        during initialization, defaults to empty dictionary.
                 
             Attributes:
                     outgoing_packets:
@@ -77,6 +79,15 @@ class Host(object):
     def get_id(self):
         """Returns host ID."""
         return self.host_id
+    
+    def add_flow(self, flow):
+        """Insert a sending flow into the host."""
+        self.flows[flow.get_id()] = flow
+        
+    def add_link(self, link):
+        """Connect the host to a link, provided one does not already exist."""
+        assert(self.link == None)
+        self.link = link
         
     def remove_flow(self, flow_id):
         """Remove flow from host. It is a good convention for flows that have

--- a/host.py
+++ b/host.py
@@ -40,18 +40,19 @@ class Host(object):
                         Initially, this should only consist of sending flows
                         since receiving flows are generated on-the-fly.
                 
-        Attributes:
-                outgoing_packets:
-                    Array of outgoing packets. Collision occurs when this array
-                    has more than one packet.
-                incoming_packets:
-                    Singleton array of packet received from internet. No
-                    possibility of collision since only one link connecting
-                    host to network.
-                send_packet:
-                    Internal event triggered when a flow wants to send packet.
-                receive_packet:
-                    Internal event trigerred when packet arrives from internet.
+            Attributes:
+                    outgoing_packets:
+                        Array of outgoing packets. Collision occurs when this
+                        array has more than one packet.
+                    incoming_packets:
+                        Singleton array of packet received from internet. No
+                        possibility of collision since only one link connecting
+                        host to network.
+                    send_packet:
+                        Internal event triggered when flow wants to send packet.
+                    receive_packet:
+                        Internal event trigerred when packet arrives from
+                        network.
         """
         
         self.env = env

--- a/host.py
+++ b/host.py
@@ -67,8 +67,8 @@ class Host(object):
         self.receive_packet = env.event()
         
         # Counters to report average per-host send/receive rate.
-        num_packets_sent = 0.0
-        num_packets_received = 0.0
+        self.num_packets_sent = 0.0
+        self.num_packets_received = 0.0
 
         # Set up host monitoring of outgoing and incoming packets.
         env.process(self.monitor_outgoing_packets(self.env))
@@ -175,7 +175,7 @@ class Host(object):
         """Report the average per-host send/receive rate in units of packets/s 
         since the last time this function was called."""
         
-        time_interval_in_s = self.env.interval * 1000.0
+        time_interval_in_s = self.env.interval * 0.001
         
         # Rate of packets sent from this host.
         host_send_rate = self.num_packets_sent / time_interval_in_s

--- a/host.py
+++ b/host.py
@@ -198,5 +198,5 @@ class Host(object):
         self.num_packets_sent = 0.0
         self.num_packets_received = 0.0
         
-        return {self.env.Measurements.host_send_rate : host_send_rate,
-                self.env.Measurements.host_receive_rate : host_receive_rate}
+        return {'host_send_rate' : host_send_rate,
+                'host_receive_rate' : host_receive_rate}

--- a/host.py
+++ b/host.py
@@ -153,8 +153,8 @@ class Host(object):
     
             # Otherwise create a new receiving flow on-the-fly. 
             else:
-                new_receiving_flow = ReceivingFlow(flow_id, self,
-                                                   incoming_packet.get_source())
+                new_receiving_flow = ReceivingFlow(env, flow_id,
+                    incoming_packet.get_source(), self)
                 self.flows[flow_id] = new_receiving_flow
                 new_receiving_flow.receive_packet(incoming_packet)
 

--- a/host.py
+++ b/host.py
@@ -67,9 +67,9 @@ class Host(object):
         self.receive_packet = env.event()
         
         # Counters to report average per-host send/receive rate.
+        interval_start_time = env.now
         num_packets_sent = 0.0
         num_packets_received = 0.0
-        interval_start_time = env.now
 
         # Set up host monitoring of outgoing and incoming packets.
         env.process(self.monitor_outgoing_packets(self.env))

--- a/host.py
+++ b/host.py
@@ -175,11 +175,13 @@ class Host(object):
         """Report the average per-host send/receive rate in units of packets/s 
         since the last time this function was called."""
         
+        time_interval_in_s = self.env.interval * 1000.0
+        
         # Rate of packets sent from this host.
-        host_send_rate = self.num_packets_sent / self.env.interval
+        host_send_rate = self.num_packets_sent / time_interval_in_s
         
         # Rate of packets received by this host.
-        host_receive_rate = self.num_packets_received / self.env.interval
+        host_receive_rate = self.num_packets_received / time_interval_in_s
         
         # Reset counters.
         self.num_packets_sent = 0.0

--- a/host.py
+++ b/host.py
@@ -13,8 +13,8 @@ class Host(object):
         Aloha method).
     
         The host delivers incoming packets to the corresponding flows based on
-        the flow_id parameter of the packet. It will dynamically generate
-        receiving_flows to handle new connections.
+        the flow_id parameter of the packet. It will dynamically generate a
+        ReceivingFlow to handle new connections.
     
         Attributes:        
                 PROCESSING_TIME:

--- a/host.py
+++ b/host.py
@@ -96,9 +96,9 @@ class Host(object):
             # collision detection.
             yield env.timeout(Host.PROCESSING_TIME)
             
-            # Send packet into network if no collisions have occured.
+            # Add packet into link buffer if no collisions have occured.
             if len(self.outgoing_packets) == 1:
-                self.link.transmit(self.outgoing_packets.pop())
+                self.link.enqueue(self.outgoing_packets.pop())
                 
             # If collision occurs, notify appropriate flows which of their
             # packets collided without sending any packets.

--- a/host.py
+++ b/host.py
@@ -155,7 +155,7 @@ class Host(object):
         self.outgoing_packets.append(outgoing_packet)
 
         # Reactivate host unless collision has occured.
-        if !self.send_packet.triggered:
+        if not self.send_packet.triggered:
             self.send_packet.succeed()
 
         
@@ -166,5 +166,5 @@ class Host(object):
         self.incoming_packets.append(incoming_packet)
 
         # Reactivate host. No possibility of collision, but check in case.
-        if !self.receive_packet.triggered:
+        if not self.receive_packet.triggered:
             self.receive_packet.succeed()        

--- a/host.py
+++ b/host.py
@@ -164,3 +164,7 @@ class Host(object):
         # Reactivate host. No possibility of collision, but check in case.
         if not self.receive_packet.triggered:
             self.receive_packet.succeed()        
+
+    def report(self):
+        """Sends measurements about flow rate."""
+        pass

--- a/host.py
+++ b/host.py
@@ -70,19 +70,19 @@ class Host(object):
         env.process(self.monitor_outgoing_packets(self.env))
         env.process(self.monitor_incoming_packets(self.env))
         
-    def get_host_id(self):
+    def get_id(self):
         """Returns host ID."""
         return self.host_id
         
     def add_sending_flow(self, sending_flow):
         """Add sending flow to host. Usable by environment to initialize flows
         after simulation has started."""
-        self.flows[sending_flow.get_flow_id()] = sending_flow
+        self.flows[sending_flow.get_id()] = sending_flow
         
-    def remove_flow(self, flow):
+    def remove_flow(self, flow_id):
         """Remove flow from host. It is a good convention for flows that have
         finished sending/receiving to remove themselves from the host."""
-        del self.flows[flow.get_flow_id()]
+        del self.flows[flow_id]
 
     def monitor_outgoing_packets(self, env):
         """

--- a/host.py
+++ b/host.py
@@ -80,14 +80,14 @@ class Host(object):
         """Returns host ID."""
         return self.host_id
     
-    def add_flow(self, flow):
-        """Insert a sending flow into the host."""
-        self.flows[flow.get_id()] = flow
-        
     def add_link(self, link):
         """Connect the host to a link, provided one does not already exist."""
         assert(self.link == None)
         self.link = link
+    
+    def add_flow(self, flow):
+        """Insert a sending flow into the host."""
+        self.flows[flow.get_id()] = flow    
         
     def remove_flow(self, flow_id):
         """Remove flow from host. It is a good convention for flows that have

--- a/host.py
+++ b/host.py
@@ -67,8 +67,8 @@ class Host(object):
         self.receive_packet = env.event()
 
         # Set up host monitoring of outgoing and incoming packets.
-        env.process(self.monitor_outgoing_packets(), self.env)
-        env.process(self.monitor_incoming_packets(), self.env)
+        env.process(self.monitor_outgoing_packets(self.env))
+        env.process(self.monitor_incoming_packets(self.env))
         
     def get_host_id(self):
         """Returns host ID."""

--- a/host.py
+++ b/host.py
@@ -67,7 +67,6 @@ class Host(object):
         self.receive_packet = env.event()
         
         # Counters to report average per-host send/receive rate.
-        interval_start_time = env.now
         num_packets_sent = 0.0
         num_packets_received = 0.0
 
@@ -176,20 +175,13 @@ class Host(object):
         """Report the average per-host send/receive rate in units of packets/s 
         since the last time this function was called."""
         
-        # Conversion factor from milliseconds to seconds.
-        MS_TO_S = 1000
-
-        # Amount of time elapsed in seconds since the last report.
-        time_interval = (self.env.now - self.interval_start_time) * MS_TO_S
-        
         # Rate of packets sent from this host.
-        host_send_rate = self.num_packets_sent / time_interval
+        host_send_rate = self.num_packets_sent / self.env.interval
         
         # Rate of packets received by this host.
-        host_receive_rate = self.num_packets_received / time_interval
+        host_receive_rate = self.num_packets_received / self.env.interval
         
         # Reset counters.
-        self.interval_start_time = self.env.now
         self.num_packets_sent = 0.0
         self.num_packets_received = 0.0
         

--- a/host.py
+++ b/host.py
@@ -1,0 +1,169 @@
+"""Defines the properties and methods of network host processes."""
+
+from flow import ReceivingFlow
+
+class Host(object):
+    """ 
+        A host represents an endpoint device containing multiple sending and
+        receiving flow connections.
+    
+        The host takes packets from its flows and feeds it into the link. A
+        collision results in no sent packets, though the involved flows are
+        notified. They can in turn follow a collision control protocol (e.g.,
+        Aloha method).
+    
+        The host delivers incoming packets to the corresponding flows based on
+        the flow_id parameter of the packet. It will dynamically generate
+        receiving_flows to handle new connections.
+    
+        Attributes:        
+                PROCESSING_TIME:
+                    Amount of time for host to respond to packet send
+                    requests. Primarily for implementing collision detection.
+    """
+
+    PROCESSING_TIME = 0.0000000000000001
+    
+    def __init__(self, env, host_id, link, flows):
+        """
+            Sets up a network endpoint host object.
+        
+            Args:            
+                    env:
+                        SimPy environment in which host resides.
+                    host_id:
+                        Identification number of host.
+                    link:
+                        Link object connecting host to the internet.
+                    flows:
+                        Dictionary of flows within host with flow IDs as keys.
+                        Initially, this should only consist of sending flows
+                        since receiving flows are generated on-the-fly.
+                
+        Attributes:
+                outgoing_packets:
+                    Array of outgoing packets. Collision occurs when this array
+                    has more than one packet.
+                incoming_packets:
+                    Singleton array of packet received from internet. No
+                    possibility of collision since only one link connecting
+                    host to network.
+                send_packet:
+                    Internal event triggered when a flow wants to send packet.
+                receive_packet:
+                    Internal event trigerred when packet arrives from internet.
+        """
+        
+        self.env = env
+        self.host_id = host_id
+        self.link = link
+        self.flows = flows
+        
+        # Set up packet buffers and notification events.
+        self.outgoing_packets = []
+        self.incoming_packets = []
+        self.send_packet = env.event()
+        self.receive_packet = env.event()
+
+        # Set up host monitoring of outgoing and incoming packets.
+        env.process(self.monitor_outgoing_packets(), self.env)
+        env.process(self.monitor_incoming_packets(), self.env)
+        
+    def get_host_id(self):
+        """Returns host ID."""
+        return self.host_id
+        
+    def add_sending_flow(self, sending_flow):
+        """Add sending flow to host. Usable by environment to initialize flows
+        after simulation has started."""
+        self.flows[sending_flow.get_flow_id()] = sending_flow
+        
+    def remove_flow(self, flow):
+        """Remove flow from host. It is a good convention for flows that have
+        finished sending/receiving to remove themselves from the host."""
+        del self.flows[flow.get_flow_id()]
+
+    def monitor_outgoing_packets(self, env):
+        """
+            Host passivates until an internal flow calls send_packet. Upon
+            reactivation, it waits for PROCESSING_TIME to gather all
+            simultaneous outgoing packet requests. It sends a packet if only one
+            request is issued, otherwise it notifies the corresponding hosts of
+            a collision without sending any packets.
+        """
+        
+        while True:
+            # Passivate until a flow wants to send a packet.
+            yield self.send_packet
+            
+            # Process outgoing packet requests from flows. Necessary for
+            # collision detection.
+            yield env.timeout(Host.PROCESSING_TIME)
+            
+            # Send packet into network if no collisions have occured.
+            if len(self.outgoing_packets) == 1:
+                self.link.transmit(self.outgoing_packets.pop())
+                
+            # If collision occurs, notify appropriate flows which of their
+            # packets collided without sending any packets.
+            else:
+                for packet in self.outgoing_packets:
+                    flow = self.flows[packet.get_flow_id()]
+                    flow.notify_collision(packet.get_sequence_number())
+
+                self.outgoing_packets = []
+
+            # Reset outgoing packet notification event.
+            self.send_packet = env.event()
+
+    def monitor_incoming_packets(self, env):
+        """
+            Host passivates until link calls receive_packet. Upon reactivation,
+            it attempts to forward the incoming packet to the corresponding
+            flow. If a flow does not exist to handle the incoming packet, a
+            receiving flow is generated on-the-fly.
+        """
+
+        while True:
+            # Passivate until a packet arrives from the link.
+            yield self.receive_packet
+
+            # Assuming one link per host, no collisions can occur and
+            # incoming_packets buffer necessarily has only one packet in it.
+            incoming_packet = self.incoming_packets.pop()
+            flow_id = incoming_packet.get_flow_id()
+
+            # Immediately forward incoming packet to corresponding flow, if it
+            # exists.
+            if flow_id in self.flows:
+                self.flows[flow_id].receive_packet(incoming_packet)
+    
+            # Otherwise create a new receiving flow on-the-fly. 
+            else:
+                new_receiving_flow = ReceivingFlow(flow_id)
+                self.flows[flow_id] = new_receiving_flow
+                new_receiving_flow.receive_packet(incoming_packet)
+
+            # Reset incoming packet notification event.
+            self.receive_packet = env.event()            
+
+    def send_packet(self, outgoing_packet):
+        """Method called by internal flows to send packets into the network."""
+        
+        # Add packet to outgoing_packet buffer.
+        self.outgoing_packets.append(outgoing_packet)
+
+        # Reactivate host unless collision has occured.
+        if !self.send_packet.triggered:
+            self.send_packet.succeed()
+
+        
+    def receive_packet(self, incoming_packet):
+        """Method called by link to transmit packet into the host."""
+
+        # Add packet to incoming_packet buffer.
+        self.incoming_packets.append(incoming_packet)
+
+        # Reactivate host. No possibility of collision, but check in case.
+        if !self.receive_packet.triggered:
+            self.receive_packet.succeed()        

--- a/host.py
+++ b/host.py
@@ -136,7 +136,8 @@ class Host(object):
     
             # Otherwise create a new receiving flow on-the-fly. 
             else:
-                new_receiving_flow = ReceivingFlow(flow_id)
+                new_receiving_flow = ReceivingFlow(flow_id, self,
+                                                   incoming_packet.get_source())
                 self.flows[flow_id] = new_receiving_flow
                 new_receiving_flow.receive_packet(incoming_packet)
 

--- a/host.py
+++ b/host.py
@@ -74,11 +74,6 @@ class Host(object):
         """Returns host ID."""
         return self.host_id
         
-    def add_sending_flow(self, sending_flow):
-        """Add sending flow to host. Usable by environment to initialize flows
-        after simulation has started."""
-        self.flows[sending_flow.get_id()] = sending_flow
-        
     def remove_flow(self, flow_id):
         """Remove flow from host. It is a good convention for flows that have
         finished sending/receiving to remove themselves from the host."""


### PR DESCRIPTION
Hosts consist of two internal processes: monitor_outgoing_packets and monitor_incoming_packets. These follow a passivate/reactivate framework through the events send_packet and receive_packet, respectively. Note that the host class itself performs the reactivations of its two internal processes. Flows and links indirectly reactivate the internal host processes through the send_packet and receive_packet API, respectively.

Is this a suitable framework for process interaction? I like this better than interruptions since one cannot pass objects through interruptions (I think). If this looks good, let's commit to this model for future process interactions.

Tests to follow upon implementation of environment, flows, and links.
